### PR TITLE
Help example fix

### DIFF
--- a/bin/stickler
+++ b/bin/stickler
@@ -20,7 +20,7 @@ Stickler server interaction
   Examples:
     #{exec_name} push ./my_gem-1.0.0.gem --server http://stickler.example.com/
     #{exec_name} yank my_gem --version 1.0.0 --server http://stickler.example.com/
-    #{exec_name} mirror third_party --version 0.4.2 --upstream http://rubygems.org/ --server http://stickler.example.com/
+    #{exec_name} mirror third_party_gem --gem-version 0.4.2 --upstream http://rubygems.org/ --server http://stickler.example.com/
     #{exec_name} mirror --help
     #{exec_name} config --server http://stickler.example.com --upstream http://rubygems.org/
 

--- a/man/stickler.asciidoc
+++ b/man/stickler.asciidoc
@@ -116,7 +116,7 @@ Take the +third_party+ gem, version +1.4.2+ that is on *rubygems.org* and mirror
 on *stickler.example.com*
 
 -----------------------------------------------------------------------------------------------------------------
-stickler mirror third_party --version 0.4.2 --upstream http://rubygems.org/ --server http://stickler.example.com/
+stickler mirror third_party_gem --gem-version 0.4.2 --upstream http://rubygems.org/ --server http://stickler.example.com/
 stickler mirror --help 
 -----------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixed examples for mirroring a gem.

Used to be:

mirror third_party --version x.y.z

Now:

mirror third_party_gem --gem-version x.y.z
