### PR TITLE
(issue/42) fix error when version isn't specified

### DIFF
--- a/lib/stickler/client/mirror.rb
+++ b/lib/stickler/client/mirror.rb
@@ -34,7 +34,7 @@ _
             gem_name = p.leftovers.shift
           else
             gemfile_lock = p.leftovers.shift
-            raise Trollop::CommandlineError, "#{lock} must be readable" unless File.readable?( gemfile_lock )
+            raise Trollop::CommandlineError, "#{gemfile_lock} must be readable" unless File.readable?( gemfile_lock )
           end
         end
         opts[:gem_name]     = gem_name


### PR DESCRIPTION
Error message when a gem version isn't specified and a Gemfile.lock
isn't present referred to a non-existant variable, so it would print a
stack trace instead of the error message. This commit refers to the
correct variable.
