### PR TITLE
Proof-of-concept dependency API.

### DIFF
--- a/lib/stickler/middleware/gemcutter.rb
+++ b/lib/stickler/middleware/gemcutter.rb
@@ -25,6 +25,14 @@ module Stickler::Middleware
       super( app, options )
     end
 
+    get '/api/v1/dependencies' do
+      ret = params.fetch('gems', '').split(',').map do |gem_name|
+        @repo.dependencies(gem_name)
+      end.compact
+
+      Marshal.dump(ret)
+    end
+
     # gemcutter push
     post '/api/v1/gems' do
       begin

--- a/lib/stickler/repository/index.rb
+++ b/lib/stickler/repository/index.rb
@@ -22,6 +22,7 @@ module Stickler::Repository
 
     def initialize( spec_dir )
       @specs              = []
+      @full_specs         = []
       @spec_dir           = spec_dir
       @last_modified_time = nil
       @last_entry_count   = nil
@@ -119,12 +120,27 @@ module Stickler::Repository
 
       full_spec.untaint
       spec = Stickler::SpecLite.new( full_spec.name, full_spec.version, full_spec.platform )
+      @full_specs << full_spec
       @specs << spec
     end
 
     def search( find_spec )
       specs.select do |spec|
         spec =~ find_spec
+      end
+    end
+
+    def dependencies( gem_name )
+      spec = @full_specs.detect {|x| x.name == gem_name }
+      if spec
+        {
+          :name         => gem_name,
+          :number       => spec.version.to_s,
+          :platform     => spec.platform,
+          :dependencies => spec.dependencies.map {|x|
+            [x.name, x.requirement.to_s]
+          }
+        }
       end
     end
   end

--- a/lib/stickler/repository/local.rb
+++ b/lib/stickler/repository/local.rb
@@ -105,6 +105,11 @@ module Stickler::Repository
       @index = ::Stickler::Repository::Index.new( @specifications_dir )
     end
 
+    # TODO: doc
+    def dependencies( gem_name )
+      @index.dependencies(gem_name)
+    end
+
     #
     # See Api#uri
     #


### PR DESCRIPTION
Addresses #22 

TODO/Questions:
- Why is `SpecLite` used instead of full `Gem::Specification`? Should we store both, or add required dependency data to `SpecLite`?
- Is `Index` the right spot for this?
- Tests.
- Documentation.
