### PR TITLE
Fix error on push when stickler server name or service not known

### DIFF
--- a/lib/stickler/repository/remote.rb
+++ b/lib/stickler/repository/remote.rb
@@ -84,7 +84,11 @@ module ::Stickler::Repository
       resource_request( push_resource, :body => IO.read( path ) )
       return spec
     rescue Excon::Errors::Error => e
-      msg = "Failure pushing #{path} to remote repository : response code => #{e.response.status}, response message => '#{e.response.body}'"
+      if e.respond_to?(:response)
+        msg = "Failure pushing #{path} to remote repository : response code => #{e.response.status}, response message => '#{e.response.body}'"
+      else
+        msg = "Failure pushing #{path} to remote repository : #{e.inspect}"
+      end
       raise Stickler::Repository::Error, msg
     end
 

--- a/test/repository/test_api_behavior.rb
+++ b/test/repository/test_api_behavior.rb
@@ -56,6 +56,13 @@ module Stickler
       end
     end
 
+    def test_raising_error_when_pushing_to_not_existent_server
+      not_existent_repo = ::Stickler::Repository::Remote.new("http://notexistent:6789/")
+      assert_raises_kind_of( Stickler::Repository::Error ) do
+        not_existent_repo.push( @foo_gem_local_path )
+      end
+    end
+
     ########
     # Delete
     ########


### PR DESCRIPTION
Hi. Thank you for Stickler. I've been using it for a couple of years, but there was an annoying error, I needed to fix.

### Without this PR
When pushing a gem to a not existent stickler server, e.g. http://notexistent, it failed with:
```
$ stickler push test_gem-0.0.1.gem
Pushing gem(s) to http://notexistent/ ...
  /tmp/gem-test_gem/test_gem-0.0.1.gem -> /usr/local/bundle/gems/stickler-2.4.2/lib/stickler/repository/remote.rb:87:in `rescue in push': undefined method `response' for #<Excon::Error::Socket:0x007f06ccc05b00> (NoMethodError)
Did you mean?  respond_to?
	from /usr/local/bundle/gems/stickler-2.4.2/lib/stickler/repository/remote.rb:82:in `push'
	from /usr/local/bundle/gems/stickler-2.4.2/lib/stickler/client/push.rb:39:in `block in run'
	from /usr/local/bundle/gems/stickler-2.4.2/lib/stickler/client/push.rb:35:in `each'
	from /usr/local/bundle/gems/stickler-2.4.2/lib/stickler/client/push.rb:35:in `run'
	from /usr/local/bundle/gems/stickler-2.4.2/bin/stickler:47:in `<top (required)>'
	from /usr/local/bundle/bin/stickler:14:in `load'
	from /usr/local/bundle/bin/stickler:14:in `<main>'
```
So it threw an error `NoMethodError` while throwing another error, [here](https://github.com/copiousfreetime/stickler/blob/master/lib/stickler/repository/remote.rb#L87).

### After this PR
With changes from this PR:
```
$ stickler push test_gem-0.0.1.gem
Pushing gem(s) to http://notexistent/ ...
  /tmp/gem-test_gem/test_gem-0.0.1.gem -> ERROR: Failure pushing /tmp/gem-test_gem/test_gem-0.0.1.gem to remote repository : #<Excon::Error::Socket: getaddrinfo: Name or service not known (SocketError)>
```